### PR TITLE
Remove a duplicate ID for the upload form widget

### DIFF
--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -265,3 +265,25 @@ function unl_four_file($vars) {
   //theme it to add labels
   return theme('form_element', $vars);
 }
+/**
+ * Returns HTML for a managed file element.
+ *
+ * @param $variables
+ *   An associative array containing:
+ *   - element: A render element representing the file.
+ *
+ * @ingroup themeable
+ */
+function unl_four_file_managed_file($variables) {
+  /*
+   * Remove the duplicate ID from the wrapper DIV
+   * The same ID that was on the <input> was being applied
+   * to the wrapper .form-managed-file div, which was
+   * throwing errors.
+   */
+  if (isset($variables['element']['#id'])) {
+    unset($variables['element']['#id']);
+  }
+  
+  return theme_file_managed_file($variables);
+}


### PR DESCRIPTION
The same ID was being used for both the `<input>` element and its wrapper. This removes the ID from the wrapper.

It appears that the issue stems here: https://github.com/drupal/drupal/blob/7.x/modules/file/file.module#L689
